### PR TITLE
Adding support for pytorch tensors in CPU/GPU

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,45 @@
+import numpy as np
+import torch
+
+from time import process_time
+from prdc import compute_prdc, compute_prdc_torch
+
+
+num_real_samples = num_fake_samples = 10000
+feature_dim = 1000
+nearest_k = 5
+real_features = np.random.normal(loc=0.0, scale=1.0,
+                                 size=[num_real_samples, feature_dim])
+
+fake_features = np.random.normal(loc=0.0, scale=1.0,
+                                 size=[num_fake_samples, feature_dim])
+real_features_torch = torch.Tensor(real_features)
+fake_features_torch = torch.Tensor(fake_features)
+
+start_time = process_time()
+metrics = compute_prdc(real_features=real_features,
+                       fake_features=fake_features,
+                       nearest_k=nearest_k)
+print('total time (numpy/CPU): ' + str(process_time() - start_time))
+print(metrics)
+
+start_time = process_time()
+metrics = compute_prdc_torch(real_features=real_features_torch,
+                       fake_features=fake_features_torch,
+                       nearest_k=nearest_k)
+print('total time (torch/CPU): ' + str(process_time() - start_time))
+print(metrics)
+
+if torch.cuda.is_available():
+    print('profiling in GPU')
+    real_features_torch_gpu = real_features_torch.cuda()
+    fake_features_torch_gpu = fake_features_torch.cuda()
+    start_time = process_time()
+    metrics = compute_prdc_torch(real_features=real_features_torch_gpu,
+                           fake_features=fake_features_torch_gpu,
+                           nearest_k=nearest_k)
+    torch.cuda.synchronize()
+    print('total time (torch/GPU): ' + str(process_time() - start_time))
+    print(metrics)
+else:
+    print('cuda GPU not available')

--- a/prdc/__init__.py
+++ b/prdc/__init__.py
@@ -1,1 +1,7 @@
 from .prdc import compute_prdc
+
+try:
+    from .prdc_torch import compute_prdc_torch
+except ModuleNotFoundError:
+    # Error handling
+    pass

--- a/prdc/prdc_torch.py
+++ b/prdc/prdc_torch.py
@@ -1,0 +1,58 @@
+import torch
+from typing import Dict
+
+
+def nearest_neighbour_distances(input_features, nearest_k):
+    """
+    Args:
+        input_features: torch.Tensor([N, feature_dim], dtype=np.float32)
+        nearest_k: int
+    Returns:
+        Distances to kth nearest neighbours.
+    """
+    distances = torch.cdist(input_features, input_features)
+    radii = torch.kthvalue(distances, k=nearest_k + 1, dim=-1)[0]
+    return radii
+
+
+def compute_prdc_torch(real_features, fake_features, nearest_k):
+    """
+    Computes precision, recall, density, and coverage given two manifolds.
+
+    Args:
+        real_features: torch.Tensor([N, feature_dim], dtype=torch.float32)
+        fake_features: torch.Tensor([N, feature_dim], dtype=torch.float32)
+        nearest_k: int.
+    Returns:
+        dict of precision, recall, density, and coverage.
+    """
+
+    print('Num real: {} Num fake: {}'
+          .format(real_features.shape[0], fake_features.shape[0]))
+
+    real_nearest_neighbour_distances = nearest_neighbour_distances(
+        real_features, nearest_k)
+    fake_nearest_neighbour_distances = nearest_neighbour_distances(
+        fake_features, nearest_k)
+    distance_real_fake = torch.cdist(
+            real_features, fake_features)
+
+    precision = (
+            distance_real_fake < real_nearest_neighbour_distances[:, None]
+    ).any(dim=0).double().mean().item()
+
+    recall = (
+            distance_real_fake < fake_nearest_neighbour_distances[None, :]
+    ).any(dim=1).double().mean().item()
+
+    density = (1. / float(nearest_k)) * (
+            distance_real_fake < real_nearest_neighbour_distances[:, None]
+    ).sum(dim=0).double().mean().item()
+
+    coverage = (
+            distance_real_fake.min(dim=1)[0] <
+            real_nearest_neighbour_distances
+    ).double().mean().item()
+
+    return dict(precision=precision, recall=recall,
+                density=density, coverage=coverage)


### PR DESCRIPTION
Dear maintainers,

the current code is based on numpy, which makes it difficult and slow to use with pytorch tensors. I have implemented the algorithms in pure pytorch (code actually requires less lines) which has the advantage of supporting tensors in GPU, potentially increasing the speed of execution. I have also added a short benchmark script that returns the following:

```
Num real: 10000 Num fake: 10000
total time (numpy/CPU): 12.029611152000001
{'precision': 0.4626, 'recall': 0.4821, 'density': 0.93344, 'coverage': 0.963}
Num real: 10000 Num fake: 10000
total time (torch/CPU): 25.861853684
{'precision': 0.4626, 'recall': 0.4821, 'density': 0.93344, 'coverage': 0.963}
profiling in GPU
Num real: 10000 Num fake: 10000
total time (torch/GPU): 0.6094362700000033
{'precision': 0.4626, 'recall': 0.48210000000000003, 'density': 0.93344, 'coverage': 0.9630000000000001}
```

as can be seen in this example the torch code computes the exact same values, and the computation on GPU (Nvidia V100) is 20x faster. The CPU in this example is Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz

On my macbook pro laptop (2.9 GHz Quad-Core Intel Core i7) I get the following
```
Num real: 10000 Num fake: 10000
total time (numpy/CPU): 86.23858
{'precision': 0.4735, 'recall': 0.4853, 'density': 0.9622400000000001, 'coverage': 0.9637}
Num real: 10000 Num fake: 10000
total time (torch/CPU): 20.718494000000007
{'precision': 0.4735, 'recall': 0.4853, 'density': 0.9622400000000001, 'coverage': 0.9637}
cuda GPU not available
```
which shows that the pytorch CPU code can be faster than numpy, in some cases.

Hopefully this addition will be helpful to you and the community.